### PR TITLE
Added missing library into the Frontend requirements.txt file

### DIFF
--- a/NeighborlyFrontEnd/requirements.txt
+++ b/NeighborlyFrontEnd/requirements.txt
@@ -13,3 +13,4 @@ requests==2.23.0
 urllib3==1.25.9
 visitor==0.1.3
 Werkzeug==0.16.1
+feedgen==0.9.0


### PR DESCRIPTION
## Issue:

While deploying the `NeighborlyFrontEnd` flask app into Azure web app, faced this `ModuleNotFoundError: No module named 'feedgen'` error. Attached azure web app log stream screen shot for your reference.

![Flask-web-app-FE-error](https://user-images.githubusercontent.com/41512228/197411844-03afc5b0-4807-43cd-940c-24f574849463.png)


## Solution:

In this PR, Updated the requirements.txt file of `NeighborlyFrontEnd` by adding this missed `feedgen` package. 

<img width="392" alt="Screenshot 2022-10-24 at 12 52 21 AM" src="https://user-images.githubusercontent.com/41512228/197411937-58690472-1cf1-47da-8d4c-f887f28226ad.png">

This fix might help the future learners to move forward instead of spending time in debugging.
